### PR TITLE
Fixed MemberInfo.HasAttribute with a predicate ignored its predicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ implementations, a C# 8 feature.
 
 ## What's so special about that?
 
-Nothing really, but it offers that functionality through a content-only NuGet package. In other words, you can use this
+Nothing really, but it offers that functionality through a content-only NuGet package that relies on C# 12. In other words, you can use this
 package in your own packages, without the need to tie yourself to the Reflectify package. Oh, and it's used
 by [an open-source project](https://fluentassertions.com/) with over 400 million downloads.
 
 ## How do I use it?
 
-Simple, to get the properties of a type, add the `Reflectify` NuGet package and use
+Simple, to get the properties of a type, add the `Reflectify` NuGet package to a project that targets at least C# 12 and use
 
 ```csharp
 using Reflectify;

--- a/src/Reflectify/Reflectify.cs
+++ b/src/Reflectify/Reflectify.cs
@@ -9,7 +9,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -475,29 +474,36 @@ internal static class TypeExtensions
 
 internal static class MemberInfoExtensions
 {
-    public static bool HasAttribute<TAttribute>(this MemberInfo type)
+    public static bool HasAttribute<TAttribute>(this MemberInfo member)
         where TAttribute : Attribute
     {
         // Do not use MemberInfo.IsDefined
         // There is an issue with PropertyInfo and EventInfo preventing the inherit option to work.
         // https://github.com/dotnet/runtime/issues/30219
-        return Attribute.IsDefined(type, typeof(TAttribute), inherit: false);
+        return Attribute.IsDefined(member, typeof(TAttribute), inherit: false);
     }
 
-    public static bool HasAttribute<TAttribute>(this MemberInfo type,
-        Expression<Func<TAttribute, bool>> isMatchingAttributePredicate)
+    /// <summary>
+    /// Determines whether the member has an attribute of the specified type that matches the predicate.
+    /// </summary>
+    public static bool HasAttribute<TAttribute>(this MemberInfo member, Func<TAttribute, bool> predicate)
         where TAttribute : Attribute
     {
-        return false;
+        if (predicate is null)
+        {
+            throw new ArgumentNullException(nameof(predicate));
+        }
+
+        return member.GetCustomAttributes<TAttribute>().Any(a => predicate(a));
     }
 
-    public static bool HasAttributeInHierarchy<TAttribute>(this MemberInfo type)
+    public static bool HasAttributeInHierarchy<TAttribute>(this MemberInfo member)
         where TAttribute : Attribute
     {
         // Do not use MemberInfo.IsDefined
         // There is an issue with PropertyInfo and EventInfo preventing the inherit option to work.
         // https://github.com/dotnet/runtime/issues/30219
-        return Attribute.IsDefined(type, typeof(TAttribute), inherit: true);
+        return Attribute.IsDefined(member, typeof(TAttribute), inherit: true);
     }
 }
 

--- a/tests/.editorconfig
+++ b/tests/.editorconfig
@@ -4,6 +4,14 @@
 # Reason: We don't care about this in tests
 dotnet_diagnostic.CA1034.severity = none
 
+# Purpose: Specify StringComparison for clarity
+# Reason: We don't care about this in tests
+dotnet_diagnostic.CA1307.severity = none
+
+# Purpose: The behavior of 'string. StartsWith(string)' could vary based on the current user's locale settings
+# Reason: We don't care about this in tests
+dotnet_diagnostic.CA1310.severity = none
+
 # Purpose: Type is a static holder type but is neither static nor NotInheritable
 # Reason: We don't care about this in tests
 dotnet_diagnostic.CA1052.severity = none
@@ -47,6 +55,10 @@ dotnet_diagnostic.AV1010.severity = none
 # Purpose: Parameter 'flag' is of type 'bool
 # Reason: Not needed for tests
 dotnet_diagnostic.AV1564.severity = none
+
+# Purpose: Use an overload of 'StartsWith' that has a StringComparison parameter
+# Reason: Duplicate of CA1310
+dotnet_diagnostic.MA0074.severity = none
 
 # Purpose: Class is never instantiated (non-private accessibility)
 # Reason: We don't instantiate test classes directly

--- a/tests/Reflectify.Specs/MemberInfoExtensionsSpecs.cs
+++ b/tests/Reflectify.Specs/MemberInfoExtensionsSpecs.cs
@@ -1,0 +1,61 @@
+using System;
+using FluentAssertions;
+using Xunit;
+
+namespace Reflectify.Specs;
+
+public class MemberInfoExtensionsSpecs
+{
+    [Fact]
+    public void Can_determine_a_method_has_an_attribute()
+    {
+        // Arrange
+        var member = typeof(ClassWithAttributedMember).GetMethod("Method");
+
+        // Act / Assert
+        member.HasAttribute<ObsoleteAttribute>().Should().BeTrue();
+    }
+
+    [Fact]
+    public void Can_determine_a_method_has_an_attribute_using_a_specific_predicate()
+    {
+        // Arrange
+        var member = typeof(ClassWithAttributedMember).GetMethod("Method");
+
+        // Act / Assert
+        member.HasAttribute<ObsoleteAttribute>(attribute =>
+            attribute.Message!.StartsWith("Specific")).Should().BeTrue();
+    }
+
+    [Fact]
+    public void The_predicate_must_not_be_null()
+    {
+        // Arrange
+        var member = typeof(ClassWithAttributedMember).GetMethod("Method");
+
+        // Act
+        var act = () => member.HasAttribute<ObsoleteAttribute>(null).Should().BeTrue();
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>().WithMessage("*predicate*");
+    }
+
+    [Fact]
+    public void Can_determine_a_method_has_an_attribute_that_does_not_meet_a_predicate()
+    {
+        // Arrange
+        var member = typeof(ClassWithAttributedMember).GetMethod("Method");
+
+        // Act / Assert
+        member.HasAttribute<ObsoleteAttribute>(predicate =>
+            predicate.Message.Contains("*Other*")).Should().BeFalse();
+    }
+
+    private class ClassWithAttributedMember
+    {
+        [Obsolete("Specific reason")]
+        public void Method()
+        {
+        }
+    }
+}


### PR DESCRIPTION
* MemberInfo.HasAttribute with a predicate was missing an implementation
* Made a bit more explicit that this package requires C# 12.0