### PR TITLE
Optimizations

### DIFF
--- a/src/Reflectify/Reflectify.cs
+++ b/src/Reflectify/Reflectify.cs
@@ -67,7 +67,7 @@ internal static class TypeMetaDataExtensions
     public static bool HasAttribute<TAttribute>(this Type type)
         where TAttribute : Attribute
     {
-        return type.HasAttribute<TAttribute>(_ => true);
+        return type.GetCustomAttributes<TAttribute>(inherit: false).Any();
     }
 
     /// <summary>
@@ -77,7 +77,12 @@ internal static class TypeMetaDataExtensions
     public static bool HasAttribute<TAttribute>(this Type type, Func<TAttribute, bool> predicate)
         where TAttribute : Attribute
     {
-        return GetCustomAttributes(type, predicate).Any();
+        if (predicate is null)
+        {
+            throw new ArgumentNullException(nameof(predicate));
+        }
+
+        return type.GetCustomAttributes<TAttribute>(inherit: false).Any(predicate);
     }
 
     /// <summary>
@@ -87,7 +92,7 @@ internal static class TypeMetaDataExtensions
     public static bool HasAttributeInHierarchy<TAttribute>(this Type type)
         where TAttribute : Attribute
     {
-        return GetCustomAttributes<TAttribute>(type, _ => true, inherit: true).Any();
+        return type.GetCustomAttributes<TAttribute>(inherit: true).Any();
     }
 
     /// <summary>
@@ -98,7 +103,12 @@ internal static class TypeMetaDataExtensions
     public static bool HasAttributeInHierarchy<TAttribute>(this Type type, Func<TAttribute, bool> predicate)
         where TAttribute : Attribute
     {
-        return GetCustomAttributes(type, predicate, inherit: true).Any();
+        if (predicate is null)
+        {
+            throw new ArgumentNullException(nameof(predicate));
+        }
+
+        return type.GetCustomAttributes<TAttribute>(inherit: true).Any(predicate);
     }
 
     /// <summary>
@@ -107,7 +117,7 @@ internal static class TypeMetaDataExtensions
     public static TAttribute[] GetMatchingAttributes<TAttribute>(this Type type)
         where TAttribute : Attribute
     {
-        return GetCustomAttributes<TAttribute>(type, _ => true, true);
+        return (TAttribute[])type.GetCustomAttributes<TAttribute>(inherit: true);
     }
 
     /// <summary>
@@ -116,21 +126,12 @@ internal static class TypeMetaDataExtensions
     public static TAttribute[] GetMatchingAttributes<TAttribute>(this Type type, Func<TAttribute, bool> predicate)
         where TAttribute : Attribute
     {
-        return GetCustomAttributes(type, predicate, true);
-    }
-
-    private static TAttribute[] GetCustomAttributes<TAttribute>(
-        Type type, Func<TAttribute, bool> predicate, bool inherit = false)
-        where TAttribute : Attribute
-    {
         if (predicate is null)
         {
             throw new ArgumentNullException(nameof(predicate));
         }
 
-        return type.GetCustomAttributes(typeof(TAttribute), inherit)
-            .OfType<TAttribute>()
-            .Where(predicate).ToArray();
+        return type.GetCustomAttributes<TAttribute>(inherit: true).Where(predicate).ToArray();
     }
 
     /// <summary>

--- a/src/Reflectify/Reflectify.cs
+++ b/src/Reflectify/Reflectify.cs
@@ -156,7 +156,7 @@ internal static class TypeMetaDataExtensions
     {
         return actualType == expectedType ||
                expectedType.IsAssignableFrom(actualType) ||
-               (actualType.BaseType?.IsGenericType is true && actualType.BaseType?.GetGenericTypeDefinition() == expectedType);
+               (actualType.BaseType is { IsGenericType: true } && actualType.BaseType.GetGenericTypeDefinition() == expectedType);
     }
 
     /// <summary>
@@ -535,7 +535,7 @@ internal static class PropertyInfoExtensions
     /// </summary>
     public static bool IsPublic(this PropertyInfo prop)
     {
-        return prop.GetMethod?.IsPublic is true || prop.SetMethod?.IsPublic is true;
+        return prop.GetMethod is { IsPublic: true } || prop.SetMethod is { IsPublic: true };
     }
 
     /// <summary>
@@ -544,10 +544,8 @@ internal static class PropertyInfoExtensions
     /// <param name="prop">The property to check.</param>
     public static bool IsInternal(this PropertyInfo prop)
     {
-        return prop.GetMethod?.IsAssembly is true ||
-               prop.GetMethod?.IsFamilyOrAssembly is true ||
-               prop.SetMethod?.IsAssembly is true ||
-               prop.SetMethod?.IsFamilyOrAssembly is true;
+        return prop.GetMethod is { IsAssembly: true } or { IsFamilyOrAssembly: true } ||
+               prop.SetMethod is { IsAssembly: true } or { IsFamilyOrAssembly: true };
     }
 
     /// <summary>
@@ -556,7 +554,7 @@ internal static class PropertyInfoExtensions
     /// <param name="prop">The property to check.</param>
     public static bool IsAbstract(this PropertyInfo prop)
     {
-        return prop.GetMethod?.IsAbstract is true || prop.SetMethod?.IsAbstract is true;
+        return prop.GetMethod is { IsAbstract: true } || prop.SetMethod is { IsAbstract: true };
     }
 }
 

--- a/src/Reflectify/Reflectify.cs
+++ b/src/Reflectify/Reflectify.cs
@@ -606,7 +606,7 @@ internal sealed class Reflector
         LoadProperties(typeToReflect, kind);
         LoadFields(typeToReflect, kind);
 
-        Members = selectedProperties.Concat<MemberInfo>(selectedFields).ToArray();
+        Members = [.. selectedProperties, .. selectedFields];
     }
 
     private void LoadProperties(Type typeToReflect, MemberKind kind)


### PR DESCRIPTION
Had a look at the code and noticed a pitfall where `obj.Prop is true` creates an intermediate `bool?` whereas `== true` avoids that intermediate.
Additionally, by using the `or` pattern, the compiler generated code only null checks each of `GetMethod` and `SetMethod` a single time.

[SharpLab](https://sharplab.io/#v2:EYLgxg9gTgpgtADwGwBYA+ABADAAgwRgDoAlGAMwBsYwAXASwgDsBuAWACgPgIIKcBJAM79GNGFEYBDCgAoAClAgAHcTQCeIshBxLFSgJQcA3hxxm8Adh17CAcRg0Asg4AWEACYB+QkICCgwRgAW2AKNRw6QRwaKABXGBw0NFNzVPNdZTsHZxo3Lx9BADFJILowgHkof0CQsIiomPjE5PY0toylQgBlbNcPbz8A4NDwyOi4hKSUtvSbHqc+/KFi0oqqodrRhom2dgBfDi4ePiERMQlpACZ5PVUNRi1rZUN2E1bzDCsOrIXc/oLqsM6gBeYHjJpTd4zMzfey/PIDIolMpqSqAzY4UHgyYtaGzTLzHIIgEbEaYsGNHHTaHfQmLRErFFo0kgik7DgHTjsbi8ATCUTiKQUADMN2Ud002g6LzeqU+T06cKJHnqOCMfPRIxA2Jwexw0DVfMZa01YW1lN1zWpM1pvT+S0EpvCWItkLxMLmduJy2RJpZzrZ8V2eyAA==)

Secondly I noticed that checking for _existence_ of an attribute using `HasAttribute` would allocate an intermediate `TAttribute[]` only check that for emptiness.

Thirdly I saw that the two `HashSet<string>` used when constructing a `Reflector` we're kept longer than necessary. If we construct them as local variables rather than class members, they can be garbage collected.