### PR TITLE
Use `IsDefined` over `GetCustomAttributes`

### DIFF
--- a/src/Reflectify/Reflectify.cs
+++ b/src/Reflectify/Reflectify.cs
@@ -67,7 +67,7 @@ internal static class TypeMetaDataExtensions
     public static bool HasAttribute<TAttribute>(this Type type)
         where TAttribute : Attribute
     {
-        return type.GetCustomAttributes<TAttribute>(inherit: false).Any();
+        return type.IsDefined(typeof(TAttribute), inherit: false);
     }
 
     /// <summary>
@@ -92,7 +92,7 @@ internal static class TypeMetaDataExtensions
     public static bool HasAttributeInHierarchy<TAttribute>(this Type type)
         where TAttribute : Attribute
     {
-        return type.GetCustomAttributes<TAttribute>(inherit: true).Any();
+        return type.IsDefined(typeof(TAttribute), inherit: true);
     }
 
     /// <summary>


### PR DESCRIPTION
Realised that with 0b2e98a882016e19765eeca68cebb2ec1854b316 in, we can do further optimizations by using `IsDefined` directly instead of getting all attributes with `GetCustomAttributes` and then check that array for emptiness.