### PR TITLE
Adjust preprocessors to select better overloads

### DIFF
--- a/src/Reflectify/Reflectify.cs
+++ b/src/Reflectify/Reflectify.cs
@@ -192,7 +192,7 @@ internal static class TypeMetaDataExtensions
             return false;
         }
 
-#if !(NET47 || NETSTANDARD2_0)
+#if NETCOREAPP2_0_OR_GREATER || NET471_OR_GREATER || NETSTANDARD2_1_OR_GREATER
         return typeof(ITuple).IsAssignableFrom(type);
 #else
         Type openType = type.GetGenericTypeDefinition();
@@ -524,10 +524,10 @@ internal static class PropertyInfoExtensions
     /// </summary>
     public static bool IsExplicitlyImplemented(this PropertyInfo prop)
     {
-#if NETCOREAPP3_0_OR_GREATER
-        return prop.Name.Contains('.', StringComparison.OrdinalIgnoreCase);
-#else
+#if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
         return prop.Name.Contains('.');
+#else
+        return prop.Name.IndexOf('.') != -1;
 #endif
     }
 


### PR DESCRIPTION
This picks the best overloads for more TFMs.
See the "Applies to" sections for [`ITuple`](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.ituple?view=net-9.0#applies-to) and [string.Contains(char)](https://learn.microsoft.com/en-us/dotnet/api/system.string.contains?view=net-9.0#system-string-contains(system-char)).

I also noticed that for `Contains('.')` for older frameworks where `string.Contains(char)` is not available we would treat the `prop.Name` as an `IEnumerable<char>` and use LINQ's `Contains(char)`.