### PR TITLE
Extend IsCompilerGenerated to check for CompilerGeneratedAttribute and add corresponding tests

### DIFF
--- a/src/Reflectify/Reflectify.cs
+++ b/src/Reflectify/Reflectify.cs
@@ -199,7 +199,8 @@ internal static class TypeMetaDataExtensions
     /// </remarks>
     public static bool IsCompilerGenerated(this Type type)
     {
-        return type.IsRecord() ||
+        return type.HasAttribute<CompilerGeneratedAttribute>() ||
+               type.IsRecord() ||
                type.IsAnonymous() ||
                type.IsTuple();
     }

--- a/tests/Reflectify.Specs/TypeMetaDataExtensionsSpecs.cs
+++ b/tests/Reflectify.Specs/TypeMetaDataExtensionsSpecs.cs
@@ -526,6 +526,21 @@ public class TypeMetaDataExtensionsSpecs
             result.Should().BeFalse();
         }
 
+        [Fact]
+        public void A_type_with_compiler_generated_attribute_is_compiler_generated()
+        {
+            // Act
+            bool result = typeof(TypeWithCompilerGeneratedAttribute).IsCompilerGenerated();
+
+            // Assert
+            result.Should().BeTrue();
+        }
+
+        [System.Runtime.CompilerServices.CompilerGenerated]
+        private class TypeWithCompilerGeneratedAttribute
+        {
+        }
+
         private record SomeRecord(string SomeProperty);
     }
 


### PR DESCRIPTION
The commit broadens the “compiler-generated” detection logic so a type is treated as compiler-generated not only when it matches known patterns (like records/anonymous/tuples), but also when it’s explicitly marked with CompilerGeneratedAttribute. 

Fixes #120