### PR TITLE
Change update interval to monthly for dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "monday"
       time: "16:00"
       timezone: "Europe/Copenhagen"
@@ -11,7 +11,7 @@ updates:
   - package-ecosystem: "nuget"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     groups:
       minor-dependencies:
         applies-to: version-updates


### PR DESCRIPTION
Changed the update schedule for GitHub Actions and NuGet from weekly to monthly.