### PR TITLE
Optimize `IsCompilerGenerated`

### DIFF
--- a/src/Reflectify/Reflectify.cs
+++ b/src/Reflectify/Reflectify.cs
@@ -201,7 +201,6 @@ internal static class TypeMetaDataExtensions
     {
         return type.HasAttribute<CompilerGeneratedAttribute>() ||
                type.IsRecord() ||
-               type.IsAnonymous() ||
                type.IsTuple();
     }
 


### PR DESCRIPTION
Since anonymous types are annotated with `CompilerGeneratedAttribute`, `HasAttribute<CompilerGeneratedAttribute>()` is sufficient.

The decreased coverage is because I deleted redundant code, so the missing branches now take up a larger percentage of the total code.
If we instead compare the number of _uncovered_ branches and lines, they are unchanged
<img width="2246" height="349" alt="image" src="https://github.com/user-attachments/assets/50fa9cc8-8be6-4fb6-8465-c0a2b7dfebf7" />
