### PR TITLE
Performance improvements

### DIFF
--- a/src/Reflectify/Reflectify.cs
+++ b/src/Reflectify/Reflectify.cs
@@ -907,8 +907,8 @@ internal sealed class Reflector(Type typeToReflect, MemberKind kind)
                 {
                     if (propertiesWithName[i].Name == name)
                     {
-                        propertiesWithName.RemoveAt(i);
-                        break;
+                        propertiesWithName[i] = (name, property);
+                        return;
                     }
                 }
 

--- a/src/Reflectify/Reflectify.cs
+++ b/src/Reflectify/Reflectify.cs
@@ -690,8 +690,6 @@ internal static class MemberKindExtensions
 /// </summary>
 internal sealed class Reflector(Type typeToReflect, MemberKind kind)
 {
-    private readonly List<FieldInfo> selectedFields = new();
-    private readonly OrderedPropertyCollection selectedProperties = new();
     private readonly object lazyLoadingLock = new();
     private volatile PropertyInfo[] cachedProperties;
     private volatile FieldInfo[] cachedFields;
@@ -708,8 +706,7 @@ internal sealed class Reflector(Type typeToReflect, MemberKind kind)
                 {
                     if (cachedProperties is null)
                     {
-                        LoadProperties(typeToReflect, kind);
-                        cachedProperties = selectedProperties.ToArray();
+                        cachedProperties = LoadProperties(typeToReflect, kind);
                     }
                 }
             }
@@ -728,8 +725,7 @@ internal sealed class Reflector(Type typeToReflect, MemberKind kind)
                 {
                     if (cachedFields is null)
                     {
-                        LoadFields(typeToReflect, kind);
-                        cachedFields = selectedFields.ToArray();
+                        cachedFields = LoadFields(typeToReflect, kind);
                     }
                 }
             }
@@ -738,8 +734,10 @@ internal sealed class Reflector(Type typeToReflect, MemberKind kind)
         }
     }
 
-    private void LoadProperties(Type typeToReflect, MemberKind kind)
+    private static PropertyInfo[] LoadProperties(Type typeToReflect, MemberKind kind)
     {
+        var selectedProperties = new OrderedPropertyCollection();
+
         while (typeToReflect != null && typeToReflect != typeof(object))
         {
             BindingFlags flags = BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.NonPublic;
@@ -747,18 +745,20 @@ internal sealed class Reflector(Type typeToReflect, MemberKind kind)
 
             var allProperties = typeToReflect.GetProperties(flags);
 
-            AddNormalProperties(kind, allProperties);
+            AddNormalProperties(kind, allProperties, selectedProperties);
 
-            AddExplicitlyImplementedProperties(kind, allProperties);
+            AddExplicitlyImplementedProperties(kind, allProperties, selectedProperties);
 
-            AddInterfaceProperties(typeToReflect, kind, flags);
+            AddInterfaceProperties(typeToReflect, kind, flags, selectedProperties);
 
             // Move to the base type
             typeToReflect = typeToReflect.BaseType;
         }
+
+        return selectedProperties.ToArray();
     }
 
-    private void AddNormalProperties(MemberKind kind, PropertyInfo[] allProperties)
+    private static void AddNormalProperties(MemberKind kind, PropertyInfo[] allProperties, OrderedPropertyCollection selectedProperties)
     {
         if ((kind & (MemberKind.Public | MemberKind.Internal | MemberKind.ExplicitlyImplemented)) != MemberKind.None)
         {
@@ -778,7 +778,7 @@ internal sealed class Reflector(Type typeToReflect, MemberKind kind)
                ((kind & MemberKind.Internal) != MemberKind.None && prop.IsInternal());
     }
 
-    private void AddExplicitlyImplementedProperties(MemberKind kind, PropertyInfo[] allProperties)
+    private static void AddExplicitlyImplementedProperties(MemberKind kind, PropertyInfo[] allProperties, OrderedPropertyCollection selectedProperties)
     {
         if ((kind & MemberKind.ExplicitlyImplemented) != MemberKind.None)
         {
@@ -793,7 +793,7 @@ internal sealed class Reflector(Type typeToReflect, MemberKind kind)
     }
 
 #pragma warning disable AV1561
-    private void AddInterfaceProperties(Type typeToReflect, MemberKind kind, BindingFlags flags)
+    private static void AddInterfaceProperties(Type typeToReflect, MemberKind kind, BindingFlags flags, OrderedPropertyCollection selectedProperties)
     {
         if ((kind & MemberKind.DefaultInterfaceProperties) != MemberKind.None || typeToReflect.IsInterface)
         {
@@ -813,8 +813,9 @@ internal sealed class Reflector(Type typeToReflect, MemberKind kind)
     }
 #pragma warning restore AV1561
 
-    private void LoadFields(Type typeToReflect, MemberKind kind)
+    private static FieldInfo[] LoadFields(Type typeToReflect, MemberKind kind)
     {
+        var selectedFields = new List<FieldInfo>();
         var collectedFieldNames = new HashSet<string>();
 
         while (typeToReflect != null && typeToReflect != typeof(object))
@@ -835,6 +836,8 @@ internal sealed class Reflector(Type typeToReflect, MemberKind kind)
             // Move to the base type
             typeToReflect = typeToReflect.BaseType;
         }
+
+        return selectedFields.ToArray();
     }
 
     private static bool HasVisibility(MemberKind kind, FieldInfo field)

--- a/src/Reflectify/Reflectify.cs
+++ b/src/Reflectify/Reflectify.cs
@@ -6,7 +6,6 @@
 #nullable disable
 
 using System;
-using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -844,7 +843,7 @@ internal sealed class Reflector(Type typeToReflect, MemberKind kind)
                ((kind & MemberKind.Internal) != MemberKind.None && (field.IsAssembly || field.IsFamilyOrAssembly));
     }
 
-    private class OrderedPropertyCollection : IEnumerable<PropertyInfo>
+    private class OrderedPropertyCollection
     {
         private readonly Dictionary<string, PropertyKind> kindMap = new();
         private readonly List<(string Name, PropertyInfo Property)> propertiesWithName = new();
@@ -859,19 +858,6 @@ internal sealed class Reflector(Type typeToReflect, MemberKind kind)
             }
 
             return result;
-        }
-
-        public IEnumerator<PropertyInfo> GetEnumerator()
-        {
-            foreach (var (_, property) in propertiesWithName)
-            {
-                yield return property;
-            }
-        }
-
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return GetEnumerator();
         }
 
         private enum PropertyKind


### PR DESCRIPTION
A follow-up to the improvements from #142

1)
With the addition of `OrderedPropertyCollection.ToArray()` the implementation of `IEnumerable<PropertyInfo>` is now unused.

2)
After `cachedProperties` and `cachedFields` have been populated, `selectedProperties` and `selectedFields` are no longer needed and can now be GC'ed.
This also avoids the current eager initialization of `selectedProperties` and `selectedFields`.

I imagine you now might want `AddNormalProperties`, `AddExplicitlyImplementedProperties` and `AddInterfaceProperties` to be members on `OrderedPropertyCollection`.
Let me know if you prefer that to passing in `selectedProperties` as a parameter.

3)
`propertiesWithName` doesn't _seem_ to rely or guarantee any ordering.
If that's true, we can replace `RemoveAt`+`Add` with changing the existing entry to avoid moving elements.