### PR TITLE
Add IsNullable, IsEnumerable, IsDictionary, IsAwaitable and much more to Type

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,13 @@ Other extension methods act on `Type` directly and include:
   tuples, etc.
 * `IsAnonymous`, `IsTuple`, `IsRecord`, `IsRecordClass`, `IsRecordStruct`, `IsKeyValuePair`, `IsDelegate`, `IsStruct`, `IsRefStruct` to find these types.
 * `GetNonGenericName` to get the name of a type without the generic backtick and number of parameters.
+* `IsNullable` to check whether a type is a constructed `Nullable<T>`.
+* `IsEnumerable` and `GetElementTypeOfEnumerable` to check whether a type is an enumerable (excluding `string`) and, if so, get its element type.
+* `IsDictionary` and `TryGetDictionaryTypes` to check whether a type is a dictionary and, if so, get its key and value types.
+* `IsAwaitable` to check whether a type can be awaited using `await`, based on the compiler's awaitable pattern.
+* `IsTaskLike` to check whether a type is `Task`, `Task<T>`, `ValueTask`, or `ValueTask<T>`.
+* `IsNumeric` to check whether a type is one of the numeric primitive types (including `decimal`).
+* `IsPrimitiveOrString` to check whether a type is a CLR primitive or `string`.
 
 Additionally, Reflectify offers some helpers such as
 

--- a/src/Reflectify/TypeMetaDataExtensions.cs
+++ b/src/Reflectify/TypeMetaDataExtensions.cs
@@ -6,11 +6,13 @@
 #nullable disable
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace Reflectify;
 
@@ -330,5 +332,249 @@ internal static class TypeMetaDataExtensions
 #else
         return false;
 #endif
+    }
+
+    /// <summary>
+    /// Returns <see langword="true" /> if the type is a constructed <see cref="Nullable{T}"/> type,
+    /// or <see langword="false" /> otherwise.
+    /// </summary>
+    /// <remarks>
+    /// This uses the same check as <c>NullableOrActualType</c> (<c>type.IsGenericType &amp;&amp; type.GetGenericTypeDefinition() == typeof(Nullable&lt;&gt;)</c>),
+    /// so <c>type.IsNullable()</c> is <see langword="true" /> exactly when <c>type.NullableOrActualType()</c> returns a
+    /// different type than <paramref name="type"/> itself.
+    /// </remarks>
+    public static bool IsNullable(this Type type)
+    {
+        return type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true" /> if the type implements <see cref="IEnumerable"/> (including <see cref="IEnumerable{T}"/>),
+    /// or <see langword="false" /> otherwise.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="string"/> is explicitly excluded, even though it implements <see cref="IEnumerable{T}"/> of <see cref="char"/>.
+    /// Treating strings as enumerables is rarely what a caller wants, so this method always returns <see langword="false" />
+    /// for <see cref="string"/>.
+    /// </remarks>
+    /// <remarks>
+    /// This method only recognizes the standard <see cref="IEnumerable"/>/<see cref="IEnumerable{T}"/> interfaces.
+    /// It does not support the C# 9 pattern-based (duck-typed) <c>foreach</c>, i.e. a type that merely exposes a
+    /// public <c>GetEnumerator()</c> method without implementing <see cref="IEnumerable"/>. Recognizing the
+    /// well-known interfaces covers the vast majority of real-world use cases.
+    /// </remarks>
+    public static bool IsEnumerable(this Type type)
+    {
+        return type != typeof(string) && typeof(IEnumerable).IsAssignableFrom(type);
+    }
+
+    /// <summary>
+    /// Returns the element type of an enumerable <paramref name="type"/>, or <see langword="null" /> if the type
+    /// is not enumerable.
+    /// </summary>
+    /// <remarks>
+    /// For arrays, this returns the array's element type. For types that implement <see cref="IEnumerable{T}"/>
+    /// exactly once (directly or through an inherited interface), this returns that single <c>T</c>. When a type
+    /// implements <see cref="IEnumerable{T}"/> for multiple different element types (e.g. a type that implements
+    /// both <c>IEnumerable&lt;int&gt;</c> and <c>IEnumerable&lt;string&gt;</c>), or when the type only implements the
+    /// non-generic <see cref="IEnumerable"/>, the element type cannot be uniquely determined. In that case, this
+    /// method falls back to returning <see cref="object"/> as a safe default.
+    /// </remarks>
+    public static Type GetElementTypeOfEnumerable(this Type type)
+    {
+        if (!type.IsEnumerable())
+        {
+            return null;
+        }
+
+        if (type.IsArray)
+        {
+            return type.GetElementType();
+        }
+
+        Type[] elementTypes = type.GetClosedGenericInterfacesIncludingSelf(typeof(IEnumerable<>))
+            .Select(i => i.GetGenericArguments()[0])
+            .Distinct()
+            .ToArray();
+
+        return elementTypes.Length == 1 ? elementTypes[0] : typeof(object);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true" /> if the type implements <see cref="IDictionary"/> or a closed
+    /// <see cref="IDictionary{TKey,TValue}"/> or <see cref="IReadOnlyDictionary{TKey,TValue}"/>, or <see langword="false" /> otherwise.
+    /// </summary>
+    public static bool IsDictionary(this Type type)
+    {
+        return typeof(IDictionary).IsAssignableFrom(type)
+               || type.GetClosedGenericInterfacesIncludingSelf(typeof(IDictionary<,>)).Length > 0
+               || type.GetClosedGenericInterfacesIncludingSelf(typeof(IReadOnlyDictionary<,>)).Length > 0;
+    }
+
+    /// <summary>
+    /// Attempts to get the key and value types of a dictionary <paramref name="type"/>.
+    /// </summary>
+    /// <returns>
+    /// <see langword="true" /> and the key and value types if <paramref name="type"/> implements a closed
+    /// <see cref="IDictionary{TKey,TValue}"/> or <see cref="IReadOnlyDictionary{TKey,TValue}"/>; otherwise,
+    /// <see langword="false" /> with both out parameters set to <see langword="null" />.
+    /// </returns>
+    /// <remarks>
+    /// Types that only implement the non-generic <see cref="IDictionary"/> (and hence do return
+    /// <see langword="true" /> from <see cref="IsDictionary"/>) do not carry key/value type information and will
+    /// therefore make this method return <see langword="false" />.
+    /// </remarks>
+    public static bool TryGetDictionaryTypes(this Type type, out Type keyType, out Type valueType)
+    {
+        Type match = type.GetClosedGenericInterfacesIncludingSelf(typeof(IDictionary<,>)).FirstOrDefault()
+                      ?? type.GetClosedGenericInterfacesIncludingSelf(typeof(IReadOnlyDictionary<,>)).FirstOrDefault();
+
+        if (match is not null)
+        {
+            Type[] genericArguments = match.GetGenericArguments();
+            keyType = genericArguments[0];
+            valueType = genericArguments[1];
+            return true;
+        }
+
+        keyType = null;
+        valueType = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Returns <see langword="true" /> if the type can be awaited using the C# <c>await</c> keyword, or
+    /// <see langword="false" /> otherwise.
+    /// </summary>
+    /// <remarks>
+    /// This is a reflection-based duck-typing check that mirrors what the C# compiler itself requires of an
+    /// awaitable type: a public, parameterless, instance <c>GetAwaiter()</c> method whose return type (the
+    /// "awaiter") has a public <c>IsCompleted</c> property, a public parameterless <c>GetResult()</c> method, and
+    /// implements <see cref="INotifyCompletion"/>. The awaiter type itself does not need to come from a specific
+    /// namespace or assembly; any type that satisfies this shape is recognized.
+    /// </remarks>
+    public static bool IsAwaitable(this Type type)
+    {
+        MethodInfo getAwaiter = type.GetMethod("GetAwaiter", BindingFlags.Public | BindingFlags.Instance, null,
+            Type.EmptyTypes, null);
+
+        if (getAwaiter is null)
+        {
+            return false;
+        }
+
+        Type awaiterType = getAwaiter.ReturnType;
+
+        bool hasIsCompleted = awaiterType.GetProperty("IsCompleted", BindingFlags.Public | BindingFlags.Instance)
+            ?.GetMethod?.IsPublic == true;
+
+        bool hasGetResult = awaiterType.GetMethod("GetResult", BindingFlags.Public | BindingFlags.Instance, null,
+            Type.EmptyTypes, null) is not null;
+
+        bool implementsNotifyCompletion = typeof(INotifyCompletion).IsAssignableFrom(awaiterType);
+
+        return hasIsCompleted && hasGetResult && implementsNotifyCompletion;
+    }
+
+    /// <summary>
+    /// Returns <see langword="true" /> if the type is <see cref="Task"/>, a constructed <see cref="Task{TResult}"/>,
+    /// <c>ValueTask</c>, or a constructed <c>ValueTask&lt;TResult&gt;</c>, or <see langword="false" /> otherwise.
+    /// </summary>
+    /// <remarks>
+    /// Unlike <see cref="IsAwaitable"/>, this is a narrower check for these specific, concrete BCL types rather than
+    /// a general awaitable duck-type check. <c>ValueTask</c> and <c>ValueTask&lt;TResult&gt;</c> are not part
+    /// of the reference assemblies of every target framework this library supports (on net47 and netstandard2.0 they
+    /// are only available through the <c>System.Threading.Tasks.Extensions</c> package), so they are recognized by
+    /// their full name rather than through a direct <c>typeof</c> reference, keeping this method available - and
+    /// correct - on every supported target framework regardless of which packages the consumer has installed.
+    /// </remarks>
+    public static bool IsTaskLike(this Type type)
+    {
+        if (type == typeof(Task) || (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Task<>)))
+        {
+            return true;
+        }
+
+        if (type.FullName == "System.Threading.Tasks.ValueTask")
+        {
+            return true;
+        }
+
+        if (type.IsGenericType && type.GetGenericTypeDefinition().FullName == "System.Threading.Tasks.ValueTask`1")
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Returns <see langword="true" /> if the type is one of the numeric primitive types (<see cref="byte"/>,
+    /// <see cref="sbyte"/>, <see cref="short"/>, <see cref="ushort"/>, <see cref="int"/>, <see cref="uint"/>,
+    /// <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/>, or <see cref="decimal"/>),
+    /// or <see langword="false" /> otherwise.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="decimal"/> is included explicitly because, unlike the other numeric types, it is not considered
+    /// a CLR primitive (<c>typeof(decimal).IsPrimitive</c> is <see langword="false" />).
+    /// </remarks>
+    /// <remarks>
+    /// <see cref="Nullable{T}"/> forms of these types (e.g. <c>int?</c>) are considered <b>not</b> numeric by this
+    /// method; the check applies to the type itself only. Callers that want nullable-aware numeric checks should
+    /// first unwrap the type, for instance using <c>NullableOrActualType</c>.
+    /// </remarks>
+    public static bool IsNumeric(this Type type)
+    {
+        return type == typeof(byte)
+               || type == typeof(sbyte)
+               || type == typeof(short)
+               || type == typeof(ushort)
+               || type == typeof(int)
+               || type == typeof(uint)
+               || type == typeof(long)
+               || type == typeof(ulong)
+               || type == typeof(float)
+               || type == typeof(double)
+               || type == typeof(decimal);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true" /> if the type is a CLR primitive type or <see cref="string"/>, or
+    /// <see langword="false" /> otherwise.
+    /// </summary>
+    /// <remarks>
+    /// This follows the underlying <see cref="Type.IsPrimitive"/> CLR semantics as-is, which has a couple of
+    /// notable quirks: <see cref="decimal"/> is <b>not</b> considered primitive (see <see cref="IsNumeric"/> if you
+    /// need to include it), while <see cref="IntPtr"/> and <see cref="UIntPtr"/> <b>are</b> considered primitive on
+    /// some but not all frameworks/runtimes. This method intentionally does not attempt to normalize that
+    /// framework-dependent behavior and simply defers to <see cref="Type.IsPrimitive"/>.
+    /// </remarks>
+    public static bool IsPrimitiveOrString(this Type type)
+    {
+        return type.IsPrimitive || type == typeof(string);
+    }
+
+    /// <summary>
+    /// Returns the closed generic interfaces implemented by <paramref name="type"/> that close over
+    /// <paramref name="openGenericType"/>, adapting <see cref="GetClosedGenericInterfaces"/> to also cover the case
+    /// where <paramref name="type"/> itself, or one of the interfaces it directly implements, is already a closed
+    /// version of <paramref name="openGenericType"/> (a case <see cref="GetClosedGenericInterfaces"/> does not
+    /// cover on its own, since it only looks for the open generic type among the interfaces of the interfaces
+    /// implemented by <paramref name="type"/>).
+    /// </summary>
+    private static Type[] GetClosedGenericInterfacesIncludingSelf(this Type type, Type openGenericType)
+    {
+        IEnumerable<Type> self = type.IsGenericType && type.GetGenericTypeDefinition() == openGenericType
+            ? [type]
+            : Type.EmptyTypes;
+
+        IEnumerable<Type> directInterfaces = type.GetInterfaces()
+            .Where(i => i.IsGenericType && i.GetGenericTypeDefinition() == openGenericType);
+
+        return self
+            .Concat(directInterfaces)
+            .Concat(type.GetClosedGenericInterfaces(openGenericType))
+            .Distinct()
+            .ToArray();
     }
 }

--- a/tests/Reflectify.Specs/Reflectify.Specs.csproj
+++ b/tests/Reflectify.Specs/Reflectify.Specs.csproj
@@ -13,6 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">

--- a/tests/Reflectify.Specs/TypeMetaDataExtensionsSpecs.cs
+++ b/tests/Reflectify.Specs/TypeMetaDataExtensionsSpecs.cs
@@ -1,5 +1,8 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Xunit;
 
@@ -1027,6 +1030,463 @@ public class TypeMetaDataExtensionsSpecs
             // Assert
             result.Should().Be<string>();
         }
+    }
+
+    public class IsNullable
+    {
+        [Fact]
+        public void A_nullable_value_type_is()
+        {
+            // Act
+            bool result = typeof(int?).IsNullable();
+
+            // Assert
+            result.Should().BeTrue();
+        }
+
+        [Fact]
+        public void A_non_nullable_value_type_is_not()
+        {
+            // Act
+            bool result = typeof(int).IsNullable();
+
+            // Assert
+            result.Should().BeFalse();
+        }
+
+        [Fact]
+        public void A_reference_type_is_not()
+        {
+            // Act
+            bool result = typeof(string).IsNullable();
+
+            // Assert
+            result.Should().BeFalse();
+        }
+    }
+
+    public class IsEnumerable
+    {
+        [Fact]
+        public void A_list_is()
+        {
+            // Act
+            bool result = typeof(List<int>).IsEnumerable();
+
+            // Assert
+            result.Should().BeTrue();
+        }
+
+        [Fact]
+        public void An_array_is()
+        {
+            // Act
+            bool result = typeof(int[]).IsEnumerable();
+
+            // Assert
+            result.Should().BeTrue();
+        }
+
+        [Fact]
+        public void A_plain_non_generic_enumerable_is()
+        {
+            // Act
+            bool result = typeof(PlainEnumerable).IsEnumerable();
+
+            // Assert
+            result.Should().BeTrue();
+        }
+
+        [Fact]
+        public void A_string_is_explicitly_excluded()
+        {
+            // Act
+            bool result = typeof(string).IsEnumerable();
+
+            // Assert
+            result.Should().BeFalse();
+        }
+
+        [Fact]
+        public void A_plain_class_is_not()
+        {
+            // Act
+            bool result = typeof(SomeOtherClass).IsEnumerable();
+
+            // Assert
+            result.Should().BeFalse();
+        }
+    }
+
+    public class GetElementTypeOfEnumerable
+    {
+        [Fact]
+        public void Returns_the_element_type_of_a_list()
+        {
+            // Act
+            Type result = typeof(List<string>).GetElementTypeOfEnumerable();
+
+            // Assert
+            result.Should().Be(typeof(string));
+        }
+
+        [Fact]
+        public void Returns_the_element_type_of_an_array()
+        {
+            // Act
+            Type result = typeof(int[]).GetElementTypeOfEnumerable();
+
+            // Assert
+            result.Should().Be(typeof(int));
+        }
+
+        [Fact]
+        public void Returns_object_for_a_type_implementing_ienumerable_of_t_more_than_once()
+        {
+            // Act
+            Type result = typeof(EnumerableOfIntAndString).GetElementTypeOfEnumerable();
+
+            // Assert
+            result.Should().Be(typeof(object));
+        }
+
+        [Fact]
+        public void Returns_object_for_a_plain_non_generic_enumerable()
+        {
+            // Act
+            Type result = typeof(PlainEnumerable).GetElementTypeOfEnumerable();
+
+            // Assert
+            result.Should().Be(typeof(object));
+        }
+
+        [Fact]
+        public void Returns_null_for_a_string()
+        {
+            // Act
+            Type result = typeof(string).GetElementTypeOfEnumerable();
+
+            // Assert
+            result.Should().BeNull();
+        }
+
+        [Fact]
+        public void Returns_null_for_a_non_enumerable_type()
+        {
+            // Act
+            Type result = typeof(SomeOtherClass).GetElementTypeOfEnumerable();
+
+            // Assert
+            result.Should().BeNull();
+        }
+    }
+
+    public class IsDictionary
+    {
+        [Fact]
+        public void A_dictionary_is()
+        {
+            // Act
+            bool result = typeof(Dictionary<string, int>).IsDictionary();
+
+            // Assert
+            result.Should().BeTrue();
+        }
+
+        [Fact]
+        public void A_read_only_dictionary_is()
+        {
+            // Act
+            bool result = typeof(IReadOnlyDictionary<string, int>).IsDictionary();
+
+            // Assert
+            result.Should().BeTrue();
+        }
+
+        [Fact]
+        public void A_list_is_not()
+        {
+            // Act
+            bool result = typeof(List<string>).IsDictionary();
+
+            // Assert
+            result.Should().BeFalse();
+        }
+
+        [Fact]
+        public void A_plain_class_is_not()
+        {
+            // Act
+            bool result = typeof(SomeOtherClass).IsDictionary();
+
+            // Assert
+            result.Should().BeFalse();
+        }
+    }
+
+    public class TryGetDictionaryTypes
+    {
+        [Fact]
+        public void Can_get_the_key_and_value_types_of_a_dictionary()
+        {
+            // Act
+            bool result = typeof(Dictionary<string, int>).TryGetDictionaryTypes(out Type keyType, out Type valueType);
+
+            // Assert
+            result.Should().BeTrue();
+            keyType.Should().Be(typeof(string));
+            valueType.Should().Be(typeof(int));
+        }
+
+        [Fact]
+        public void Can_get_the_key_and_value_types_of_a_read_only_dictionary()
+        {
+            // Act
+            bool result = typeof(IReadOnlyDictionary<string, int>).TryGetDictionaryTypes(out Type keyType, out Type valueType);
+
+            // Assert
+            result.Should().BeTrue();
+            keyType.Should().Be(typeof(string));
+            valueType.Should().Be(typeof(int));
+        }
+
+        [Fact]
+        public void Returns_false_for_a_non_dictionary_type()
+        {
+            // Act
+            bool result = typeof(List<string>).TryGetDictionaryTypes(out Type keyType, out Type valueType);
+
+            // Assert
+            result.Should().BeFalse();
+            keyType.Should().BeNull();
+            valueType.Should().BeNull();
+        }
+    }
+
+    public class IsAwaitable
+    {
+        [Fact]
+        public void A_task_is()
+        {
+            // Act
+            bool result = typeof(Task).IsAwaitable();
+
+            // Assert
+            result.Should().BeTrue();
+        }
+
+        [Fact]
+        public void A_task_of_t_is()
+        {
+            // Act
+            bool result = typeof(Task<int>).IsAwaitable();
+
+            // Assert
+            result.Should().BeTrue();
+        }
+
+        [Fact]
+        public void A_value_task_is()
+        {
+            // Act
+            bool result = typeof(ValueTask).IsAwaitable();
+
+            // Assert
+            result.Should().BeTrue();
+        }
+
+        [Fact]
+        public void A_value_task_of_t_is()
+        {
+            // Act
+            bool result = typeof(ValueTask<int>).IsAwaitable();
+
+            // Assert
+            result.Should().BeTrue();
+        }
+
+        [Fact]
+        public void A_custom_duck_typed_awaitable_is()
+        {
+            // Act
+            bool result = typeof(CustomAwaitable).IsAwaitable();
+
+            // Assert
+            result.Should().BeTrue();
+        }
+
+        [Fact]
+        public void A_non_awaitable_type_is_not()
+        {
+            // Act
+            bool result = typeof(SomeOtherClass).IsAwaitable();
+
+            // Assert
+            result.Should().BeFalse();
+        }
+    }
+
+    public class IsTaskLike
+    {
+        [Fact]
+        public void A_task_is()
+        {
+            // Act
+            bool result = typeof(Task).IsTaskLike();
+
+            // Assert
+            result.Should().BeTrue();
+        }
+
+        [Fact]
+        public void A_task_of_t_is()
+        {
+            // Act
+            bool result = typeof(Task<int>).IsTaskLike();
+
+            // Assert
+            result.Should().BeTrue();
+        }
+
+        [Fact]
+        public void A_value_task_is()
+        {
+            // Act
+            bool result = typeof(ValueTask).IsTaskLike();
+
+            // Assert
+            result.Should().BeTrue();
+        }
+
+        [Fact]
+        public void A_value_task_of_t_is()
+        {
+            // Act
+            bool result = typeof(ValueTask<int>).IsTaskLike();
+
+            // Assert
+            result.Should().BeTrue();
+        }
+
+        [Fact]
+        public void A_custom_duck_typed_awaitable_is_not()
+        {
+            // Act
+            bool result = typeof(CustomAwaitable).IsTaskLike();
+
+            // Assert
+            result.Should().BeFalse();
+        }
+
+        [Fact]
+        public void A_non_awaitable_type_is_not()
+        {
+            // Act
+            bool result = typeof(SomeOtherClass).IsTaskLike();
+
+            // Assert
+            result.Should().BeFalse();
+        }
+    }
+
+    public class IsNumeric
+    {
+        [Theory]
+        [InlineData(typeof(byte))]
+        [InlineData(typeof(sbyte))]
+        [InlineData(typeof(short))]
+        [InlineData(typeof(ushort))]
+        [InlineData(typeof(int))]
+        [InlineData(typeof(uint))]
+        [InlineData(typeof(long))]
+        [InlineData(typeof(ulong))]
+        [InlineData(typeof(float))]
+        [InlineData(typeof(double))]
+        [InlineData(typeof(decimal))]
+        public void A_numeric_type_is(Type type)
+        {
+            // Act
+            bool result = type.IsNumeric();
+
+            // Assert
+            result.Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineData(typeof(bool))]
+        [InlineData(typeof(char))]
+        [InlineData(typeof(string))]
+        [InlineData(typeof(SomeOtherClass))]
+        [InlineData(typeof(int?))]
+        public void A_non_numeric_type_is_not(Type type)
+        {
+            // Act
+            bool result = type.IsNumeric();
+
+            // Assert
+            result.Should().BeFalse();
+        }
+    }
+
+    public class IsPrimitiveOrString
+    {
+        [Theory]
+        [InlineData(typeof(int))]
+        [InlineData(typeof(bool))]
+        [InlineData(typeof(char))]
+        [InlineData(typeof(double))]
+        [InlineData(typeof(string))]
+        public void A_primitive_or_string_type_is(Type type)
+        {
+            // Act
+            bool result = type.IsPrimitiveOrString();
+
+            // Assert
+            result.Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineData(typeof(decimal))]
+        [InlineData(typeof(SomeOtherClass))]
+        [InlineData(typeof(int?))]
+        public void A_non_primitive_and_non_string_type_is_not(Type type)
+        {
+            // Act
+            bool result = type.IsPrimitiveOrString();
+
+            // Assert
+            result.Should().BeFalse();
+        }
+    }
+
+    private class PlainEnumerable : IEnumerable
+    {
+        public IEnumerator GetEnumerator() => throw new NotSupportedException();
+    }
+
+    private class EnumerableOfIntAndString : IEnumerable<int>, IEnumerable<string>
+    {
+        IEnumerator<int> IEnumerable<int>.GetEnumerator() => throw new NotSupportedException();
+
+        IEnumerator<string> IEnumerable<string>.GetEnumerator() => throw new NotSupportedException();
+
+        IEnumerator IEnumerable.GetEnumerator() => throw new NotSupportedException();
+    }
+
+    private class CustomAwaitable
+    {
+        public CustomAwaiter GetAwaiter() => new();
+    }
+
+    private class CustomAwaiter : INotifyCompletion
+    {
+        public bool IsCompleted => true;
+
+        public void GetResult()
+        {
+        }
+
+        public void OnCompleted(Action continuation) => continuation();
     }
 
     private class OpenGenericClass<T>


### PR DESCRIPTION
## Summary

Implements the approved API proposal in #159 by adding the following extension methods on `Type` to `src/Reflectify/TypeMetaDataExtensions.cs`:

- `IsNullable` — true for constructed `Nullable<T>` types. Cross-referenced with the existing `NullableOrActualType` helper (documented in `<remarks>`).
- `IsEnumerable` — true if the type implements `IEnumerable`/`IEnumerable<T>`, explicitly excluding `string`. Documented that pattern-based (duck-typed) `foreach` is intentionally not supported, per the issue's accepted 80% scope.
- `GetElementTypeOfEnumerable` — returns the element type for arrays and single-`IEnumerable<T>` implementers; falls back to `typeof(object)` for ambiguous/multiple-interface or non-generic cases, and `null` for non-enumerables. Reuses/adapts the existing `GetClosedGenericInterfaces` helper.
- `IsDictionary` / `TryGetDictionaryTypes` — detect `IDictionary`/`IDictionary<TKey,TValue>`/`IReadOnlyDictionary<TKey,TValue>` and extract key/value types.
- `IsAwaitable` — reflection-based duck-typing check mirroring the C# compiler's awaitable pattern (`GetAwaiter()` → `IsCompleted`, `GetResult()`, `INotifyCompletion`).
- `IsTaskLike` — narrower check for `Task`, `Task<T>`, `ValueTask`, `ValueTask<T>`. Since `ValueTask`/`ValueTask<T>` aren't part of the net47/netstandard2.0 reference assemblies, they're recognized by full type name instead of a direct `typeof` reference, keeping the method correct on every target framework (net47, net6.0, netstandard2.0, netstandard2.1).
- `IsNumeric` — true for the numeric primitives plus `decimal` (which is not `Type.IsPrimitive`). Documented that `Nullable<T>` numeric forms are not considered numeric at this method's level.
- `IsPrimitiveOrString` — `type.IsPrimitive || type == typeof(string)`, with `<remarks>` documenting the `decimal`/`IntPtr` CLR quirks called out in the issue.

## Tests

Added nested test classes to `tests/Reflectify.Specs/TypeMetaDataExtensionsSpecs.cs` covering all new methods, including the multiple-`IEnumerable<T>` (diamond) case, plain non-generic `IEnumerable`, dictionaries/read-only dictionaries, `Task`/`Task<T>`/`ValueTask`/`ValueTask<T>`, a custom duck-typed awaitable, and numeric/primitive edge cases (`decimal`, `bool`, `char`, nullable forms).

Also added a `System.Threading.Tasks.Extensions` package reference for the test project's `net472` target so `ValueTask` tests compile/run there too.

## Docs

Updated the `README.md` "How do I use it?" `Type` bullet list to mention the new methods.

## Validation

- `dotnet build src\Reflectify\Reflectify.csproj` — succeeds for all 4 TFMs (net47, net6.0, netstandard2.0, netstandard2.1).
- `dotnet test tests\Reflectify.Specs\Reflectify.Specs.csproj` — all tests pass (net8.0: 244/244, net6.0: 244/244, net472: 239/239). The `netcoreapp3.0` target failed to launch in this environment due to a missing local runtime — unrelated to this change.

Closes #159